### PR TITLE
Release veraPDF v1.20.1

### DIFF
--- a/org.verapdf.veraPDF.json
+++ b/org.verapdf.veraPDF.json
@@ -109,12 +109,12 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://software.verapdf.org/develop/2.0/verapdf-greenfield-2.0.72-installer.zip",
-                    "sha256": "9e74d3b6c6d9407a1649f31d0bfd326d1946f7a006e3efc0e9d6dc5e091ac274"
+                    "url": "https://software.verapdf.org/rel/1.20/verapdf-greenfield-1.20.1-installer.zip",
+                    "sha256": "3348aa37d1833bc294911a0db4fe49fea43c2faae0abc4ad4b9c4173b4259a02"
                 },
                 {
                   "type": "file",
-                  "url": "https://raw.githubusercontent.com/veraPDF/veraPDF-apps/v2.0.68/gui/src/main/resources/org/verapdf/gui/images/icon.png",
+                  "url": "https://raw.githubusercontent.com/veraPDF/veraPDF-apps/v1.20.1/gui/src/main/resources/org/verapdf/gui/images/icon.png",
                   "sha256": "32a7bbe7a7107dffa44cf601fc2af818806d6b9ca13056cea9f033264ced0b4f"
                 },
                 {

--- a/org.verapdf.veraPDF.metainfo.xml
+++ b/org.verapdf.veraPDF.metainfo.xml
@@ -15,54 +15,67 @@
   </description>
   <screenshots>
   	<screenshot type="default">
-    <image type="source">https://docs.verapdf.org/images/gui/main-screen.png</image>
-    <caption>Main screen</caption>
+      <image type="source">https://docs.verapdf.org/images/gui/main-screen.png</image>
+      <caption>Main screen</caption>
     </screenshot>
     <screenshot>
-    <image type="source">https://docs.verapdf.org/images/gui/profile-list.png</image>
-    <caption>Profile options</caption>
+      <image type="source">https://docs.verapdf.org/images/gui/profile-list.png</image>
+      <caption>Profile options</caption>
     </screenshot>
     <screenshot>
-    <image type="source">https://docs.verapdf.org/images/gui/report-list.png</image>
-    <caption>Report options</caption>
+      <image type="source">https://docs.verapdf.org/images/gui/report-list.png</image>
+      <caption>Report options</caption>
     </screenshot>
     <screenshot>
-    <image type="source">https://docs.verapdf.org/images/gui/settings.png</image>
-    <caption>Settings</caption>
+      <image type="source">https://docs.verapdf.org/images/gui/settings.png</image>
+      <caption>Settings</caption>
     </screenshot>
   </screenshots>
   <url type="homepage">https://verapdf.org</url>
   <update_contact>nbenitezl_AT_gmail.com</update_contact>
   <content_rating type="oars-1.1"/>
   <releases>
-  	<release version="2.0.72" date="2021-01-30">
-    <description>
-      <ul>
+    <release version="1.20.1" date="2022-01-20">
+      <description>
+        <ul>
+          <li>New version 1.20.1</li>
+          <li>This supercedes the previous 2.0.72 build released in error.</li>
+          <li>The official build of the latest veraPDF version.</li>
+          <li>Adds PDF/A-4 support including Level F and Level E</li>
+          <li>Support of Java 11 through 16</li>
+          <li>Improved: handling of malicious docs., parsing of PostScript and CFF fonts</li>
+        </ul>
+      </description>
+      <url>https://github.com/veraPDF/veraPDF-apps/releases/tag/v1.20.1</url>
+    </release>
+    <release version="2.0.72" date="2021-01-30">
+      <description>
+        <ul>
           <li>New version 2.0.72</li>
           <li>Flathub packaging: Rename CLI command to official name 'verapdf'. Example calls:</li>
           <li>flatpak run --command=verapdf org.verapdf.veraPDF --help</li>
           <li>flatpak run --command=verapdf org.verapdf.veraPDF -x some_file.pdf</li>
-      </ul>
-    </description>
-    <url>https://github.com/veraPDF/veraPDF-apps/releases/tag/v2.0.72</url>
+        </ul>
+      </description>
+      <url>https://github.com/veraPDF/veraPDF-apps/releases/tag/v2.0.72</url>
     </release>
     <release version="1.17.31-1" date="2021-01-29">
-    <description>
-      <ul>
+      <description>
+        <ul>
           <li>Flathub package improvement minor release:</li>
           <li>Adds command line version of the program, it can be run from terminal as:</li>
           <li>flatpak run --command=verapdf-cli org.verapdf.veraPDF --help</li>
-      </ul>
-    </description>
-    <url>https://github.com/veraPDF/veraPDF-apps/releases/tag/v1.17.31</url>
+        </ul>
+      </description>
+      <url>https://github.com/veraPDF/veraPDF-apps/releases/tag/v1.17.31</url>
     </release>
     <release version="1.17.31" date="2020-12-29">
-    <description>
-      <ul>
+      <description>
+        <ul>
           <li>Various updates</li>
-      </ul>
-    </description>
-    <url>https://github.com/veraPDF/veraPDF-apps/releases/tag/v1.17.31</url>
+        </ul>
+      </description>
+      <url>https://github.com/veraPDF/veraPDF-apps/releases/tag/v1.17.31</url>
     </release>
   </releases>
 </component>

--- a/org.verapdf.veraPDF.metainfo.xml
+++ b/org.verapdf.veraPDF.metainfo.xml
@@ -48,17 +48,6 @@
       </description>
       <url>https://github.com/veraPDF/veraPDF-apps/releases/tag/v1.20.1</url>
     </release>
-    <release version="2.0.72" date="2021-01-30">
-      <description>
-        <ul>
-          <li>New version 2.0.72</li>
-          <li>Flathub packaging: Rename CLI command to official name 'verapdf'. Example calls:</li>
-          <li>flatpak run --command=verapdf org.verapdf.veraPDF --help</li>
-          <li>flatpak run --command=verapdf org.verapdf.veraPDF -x some_file.pdf</li>
-        </ul>
-      </description>
-      <url>https://github.com/veraPDF/veraPDF-apps/releases/tag/v2.0.72</url>
-    </release>
     <release version="1.17.31-1" date="2021-01-29">
       <description>
         <ul>


### PR DESCRIPTION
- added v1.20.1 entry to org.verapdf.veraPDF.metainfo.xml;
- updated icon reference, installer reference & associated sha256 in `org.verapdf.veraPDF.json`; and
- fixed indentation issues in XML.

**NOTE** Please review the `<releases>` section in the metainfo file. I've added the latest release but it might cause some issues as the previous "release" was version 2.0 which was in fact a development version. This won't be released any time soon and the new (22-01-20) release is v1.20.1, so by versioning convention is still an earlier release. If this approach is OK feel free to merge, if not let me know and I'll get it right next time.