### PR TITLE
REL: veraPDF v1.26

### DIFF
--- a/org.verapdf.veraPDF.desktop
+++ b/org.verapdf.veraPDF.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=veraPDF
 GenericName=PDF/A conformance validator
-Comment=veraPDF is a file-format validator covering all PDF/A parts and conformance levels
+Comment=veraPDF is an open-source, industry-supported PDF/A and PDF/UA validator
 Exec=verapdf-gui %F
 Icon=org.verapdf.veraPDF
 Terminal=false

--- a/org.verapdf.veraPDF.json
+++ b/org.verapdf.veraPDF.json
@@ -109,12 +109,12 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://software.verapdf.org/releases/1.24/verapdf-greenfield-1.24.3-installer.zip",
-                    "sha256": "065f7767cc254e611eaf784444995f5d9dfc5285f2e3145bddb5afdfc540c6ed"
+                    "url": "https://software.verapdf.org/releases/1.26/verapdf-greenfield-1.26.2-installer.zip",
+                    "sha256": "b6c50ab65d574bff0cbc0449ffacf587e325a3a53f8a6ecc0d578966abc800ec"
                 },
                 {
                   "type": "file",
-                  "url": "https://raw.githubusercontent.com/veraPDF/veraPDF-apps/v1.24.3/gui/src/main/resources/org/verapdf/gui/images/icon.png",
+                  "url": "https://raw.githubusercontent.com/veraPDF/veraPDF-apps/v1.26.2/gui/src/main/resources/org/verapdf/gui/images/icon.png",
                   "sha256": "32a7bbe7a7107dffa44cf601fc2af818806d6b9ca13056cea9f033264ced0b4f"
                 },
                 {

--- a/org.verapdf.veraPDF.metainfo.xml
+++ b/org.verapdf.veraPDF.metainfo.xml
@@ -39,16 +39,21 @@
       <description>
         <ul>
           <li>(PDF/UA-2) added support for PDF/UA-2 (draft).</li>
-          <li>(PDF/UA-2) supported named structured destinations in goto actions.</li>
-          <li>(PDF/UA-1) fixed rules about annotations.</li>
-          <li>Set secure parameter for xslt transformation CVE-2024-28109.</li>
+          <li>(PDF/UA-1) detect and report structure elements with missing parent.</li>
+          <li>(PDF/UA-1) fixed checks related to role maps between standard and non-standard tags.</li>
+          <li>(PDF/UA-1) fixed rules related to annotations in structure tree.</li>
+          <li>(PDF/UA-1) added checks for XMP prefixes in the identification metadata.</li>
+          <li>(PDF/A-1,2,3,4) added check for valid values of BitsPerComponent.</li>
+          <li>(PDF/A-2,3,4) apply the rule on identical tint transform also to /All and /None.</li>
+          <li>(PDF/A-1) added check that the document does not use xref stream.</li>
+          <li>(PDF/A-1) Fix syncing XMP with Info dictionary in case of multiple creators.</li>
+          <li>Improved REST API: more logical endpoints, documentation, web demo page, automatic deployment of the docker image to DockerHub.com.</li>
+          <li>Redesigned main GUI window.</li>
+          <li>Improved CLI output (help, debug logs, text report, JSON report formatting).</li>
+          <li>added support for Java 21.</li>
           <li>Improved multithreading performance of JavaScript evaluation.</li>
-          <li>Added support for Java 21.</li>
-          <li>(PDF/UA-2) include ISO 32005 rules to PDF/UA-2 profile.</li>
-          <li>(PDF/UA-2) added rule about Ref entry of Note structure element.</li>
-          <li>(PDF/UA-2) supported validation of Open Action destination.</li>
-          <li>(PDF/UA-2) disabled ActualText and Alt validation for non-real content.</li>
-          <li>(PDF/UA-2) fixed checking of role mapping structure types to the same namespace.</li>
+          <li>Set secure parameter for xslt transformation (CVE-2024-28109).</li>
+          <li>Updated predefined CMaps.</li>
         </ul>
       </description>
       <url>https://verapdf.org/2023/06/28/verapdf-1-24-released/</url>

--- a/org.verapdf.veraPDF.metainfo.xml
+++ b/org.verapdf.veraPDF.metainfo.xml
@@ -35,6 +35,24 @@
   <update_contact>nbenitezl_AT_gmail.com</update_contact>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="1.26" date="2024-05-22">
+      <description>
+        <ul>
+          <li>(PDF/UA-2) added support for PDF/UA-2 (draft).</li>
+          <li>(PDF/UA-2) supported named structured destinations in goto actions.</li>
+          <li>(PDF/UA-1) fixed rules about annotations.</li>
+          <li>Set secure parameter for xslt transformation CVE-2024-28109.</li>
+          <li>Improved multithreading performance of JavaScript evaluation.</li>
+          <li>Added support for Java 21.</li>
+          <li>(PDF/UA-2) include ISO 32005 rules to PDF/UA-2 profile.</li>
+          <li>(PDF/UA-2) added rule about Ref entry of Note structure element.</li>
+          <li>(PDF/UA-2) supported validation of Open Action destination.</li>
+          <li>(PDF/UA-2) disabled ActualText and Alt validation for non-real content.</li>
+          <li>(PDF/UA-2) fixed checking of role mapping structure types to the same namespace.</li>
+        </ul>
+      </description>
+      <url>https://verapdf.org/2023/06/28/verapdf-1-24-released/</url>
+    </release>
     <release version="1.24" date="2023-06-28">
       <description>
         <ul>
@@ -49,7 +67,7 @@
           <li>Assorted minor bug fixes.</li>
         </ul>
       </description>
-      <url>https://verapdf.org/2023/06/28/verapdf-1-24-released/</url>
+      <url>https://github.com/veraPDF/veraPDF-library/releases/tag/v1.24.2/</url>
     </release>
     <release version="1.22.2" date="2022-05-19">
       <description>


### PR DESCRIPTION
- added details of v1.26 to `org.verapdf.veraPDF.metainfo.xml`;
- updated the download details and SHA-256 checksums for v1.26; and
- updated the desktop file description.