### PR TITLE
REL: veraPDF v1.28.1

### DIFF
--- a/org.verapdf.veraPDF.json
+++ b/org.verapdf.veraPDF.json
@@ -109,12 +109,12 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://software.verapdf.org/releases/1.26/verapdf-greenfield-1.26.2-installer.zip",
-                    "sha256": "b6c50ab65d574bff0cbc0449ffacf587e325a3a53f8a6ecc0d578966abc800ec"
+                    "url": "https://software.verapdf.org/releases/1.28/verapdf-greenfield-1.28.1-installer.zip",
+                    "sha256": "9fb17bd6ac139df01b52e2e712046ae5f2482ef6e3d10891cb5cb6a817c624ab"
                 },
                 {
                   "type": "file",
-                  "url": "https://raw.githubusercontent.com/veraPDF/veraPDF-apps/v1.26.2/gui/src/main/resources/org/verapdf/gui/images/icon.png",
+                  "url": "https://raw.githubusercontent.com/veraPDF/veraPDF-apps/v1.28.1/gui/src/main/resources/org/verapdf/gui/images/icon.png",
                   "sha256": "32a7bbe7a7107dffa44cf601fc2af818806d6b9ca13056cea9f033264ced0b4f"
                 },
                 {

--- a/org.verapdf.veraPDF.metainfo.xml
+++ b/org.verapdf.veraPDF.metainfo.xml
@@ -38,6 +38,26 @@
     <release version="1.28.1" date="2025-05-06">
       <description>
         <ul>
+          <li>fixed parsing of empty UTF-16 string</li>
+          <li>fixed parsing of CFF fonts with empty Name Index</li>
+          <li>updated width calculation for CFFType1 font program with duplicated glyph names</li>
+          <li>fixed name calculation for glyph with code 0</li>
+          <li>fixed signature EOF logic in incremental updates</li>
+          <li>fixed parsing of compressed CIDToGIDMap stream</li>
+          <li>(WTPDF-1) added support for WTPDF Reuse and Accessibility conformance levels</li>
+          <li>(PDF/A, PDF/UA) fixes the issue of accepting sometimes string value type if the PDF specification requires name object type</li>
+          <li>(PDF/A) fixed validation of Interpolate entry in image mask dictionaries</li>
+          <li>(PDF/A-1) updated the rule on compressed XMP Metadata</li>
+          <li>(PDF/UA-1) added rule about PDF version</li>
+          <li>(PDF/UA-1) fixed recursive propagation of Artifact to untagged Form XObjects</li>
+          <li>(PDF/UA-1,2) fixed handing of circular role mappings and namespaces</li>
+          <li>(PDF/UA-1,2) permit untagged tilling patterns</li>
+          <li>(PDF/UA-2) permit math structure type only within Formula</li>
+          <li>(PDF/UA-2) added rule to require Metadata entry in Catalog</li>
+          <li>(ISO 32005) updated Div, Part, NonStruct processing to inherit containment rules from the parent</li>
+          <li>(ISO 32005) added containment rules for Ruby and Warichu</li>
+          <li>(ISO 32005) permitted Sub as a child of Code</li>
+          <li>(ISO 32005) fixed rule on content items in StructTreeRoot</li>
           <li>(PDF/UA-1,2, WTPDF-1, ISO 32005) added rules to require Marked=true entry in MarkInfo dictionary</li>
           <li>(PDF/UA-2, WTPDF-1, ISO 32005) fixed parent-child rules for NonStruct, Part and Div</li>
           <li>(PDF/UA-2, WTPDF-1, ISO 32005) fixed exception during table validation in cases of invalid table structure</li>
@@ -47,6 +67,16 @@
           <li>fixed xref parsing in some exceptional cases and improved error reporting</li>
           <li>fixed parsing of indirect Kids in number tree</li>
           <li>fixed invalid byte range parsing in CMap stream</li>
+          <li>added validation for several flavours</li>
+          <li>created docker image for veraPDF CLI</li>
+          <li>added showing location of config</li>
+          <li>improved performance</li>
+          <li>improved logs</li>
+          <li>more robust exception handling</li>
+          <li>updated PDF/A-4 and PDF/UA-2 test corpus</li>
+          <li>added WTPDF declarations to PDF/UA-2 test files</li>
+          <li>improved java docs</li>
+          <li>improved policy documentation</li>
           <li>updated izpack to version 5.2.4</li>
         </ul>
       </description>

--- a/org.verapdf.veraPDF.metainfo.xml
+++ b/org.verapdf.veraPDF.metainfo.xml
@@ -6,7 +6,7 @@
   <project_license>GPL-3.0-only</project_license>
   <developer_name>veraPDF Consortium</developer_name>
   <name>veraPDF</name>
-  <summary>veraPDF is a file-format validator for PDF/A archiving standard</summary>
+  <summary>veraPDF is a file-format validator for the PDF/A archiving standard</summary>
   <description>
     <p>
     	veraPDF is a purpose-built, open source, file-format validator covering all PDF/A parts and conformance levels.
@@ -35,6 +35,23 @@
   <update_contact>nbenitezl_AT_gmail.com</update_contact>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="1.28.1" date="2025-05-06">
+      <description>
+        <ul>
+          <li>(PDF/UA-1,2, WTPDF-1, ISO 32005) added rules to require Marked=true entry in MarkInfo dictionary</li>
+          <li>(PDF/UA-2, WTPDF-1, ISO 32005) fixed parent-child rules for NonStruct, Part and Div</li>
+          <li>(PDF/UA-2, WTPDF-1, ISO 32005) fixed exception during table validation in cases of invalid table structure</li>
+          <li>(PDF/UA-2, WTPDF-1) fixed mismatch of structure destinations in Link annotations</li>
+          <li>(PDF/UA-2, WTPDF-1) fixed rule about alternative text for signature graphic content with no text</li>
+          <li>(PDF/UA-2, WTPDF-1) fixed checking ToggleNoView flag for annotations</li>
+          <li>fixed xref parsing in some exceptional cases and improved error reporting</li>
+          <li>fixed parsing of indirect Kids in number tree</li>
+          <li>fixed invalid byte range parsing in CMap stream</li>
+          <li>updated izpack to version 5.2.4</li>
+        </ul>
+      </description>
+      <url>https://github.com/veraPDF/veraPDF-library/releases/tag/v1.28.1</url>
+    </release>
     <release version="1.26" date="2024-05-22">
       <description>
         <ul>
@@ -56,7 +73,7 @@
           <li>Updated predefined CMaps.</li>
         </ul>
       </description>
-      <url>https://verapdf.org/2023/06/28/verapdf-1-24-released/</url>
+      <url>https://github.com/veraPDF/veraPDF-library/releases/tag/v1.26.1/</url>
     </release>
     <release version="1.24" date="2023-06-28">
       <description>


### PR DESCRIPTION
- updated file links and SHA256 checksums in JSON build file; and
- added v1.28.1 details to metainfo.xml file.