### PR TITLE
MAINT: Updated Flatpak runtime

### DIFF
--- a/org.verapdf.veraPDF.json
+++ b/org.verapdf.veraPDF.json
@@ -1,10 +1,10 @@
 {
     "id": "org.verapdf.veraPDF",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "23.08",
+    "runtime-version": "25.08",
     "command": "verapdf-gui",
     "sdk": "org.freedesktop.Sdk",
-    "sdk-extensions": ["org.freedesktop.Sdk.Extension.openjdk11"],
+    "sdk-extensions": ["org.freedesktop.Sdk.Extension.openjdk17"],
     "finish-args": [
         "--env=PATH=/app/jre/bin:/app/bin:/usr/bin",
         "--env=JAVA_HOME=/app/jre",
@@ -88,7 +88,7 @@
             "name": "verapdf",
             "buildsystem": "simple",
             "build-commands": [
-                "/usr/lib/sdk/openjdk11/install.sh",
+                "/usr/lib/sdk/openjdk17/install.sh",
                 "mkdir -p /app/verapdf",
                 "convert icon.png -resize 256x256 icon256.png",
                 "install -Dm644 icon256.png /app/share/icons/hicolor/256x256/apps/org.verapdf.veraPDF.png",
@@ -110,7 +110,7 @@
                 {
                     "type": "archive",
                     "url": "https://software.verapdf.org/releases/1.28/verapdf-greenfield-1.28.1-installer.zip",
-                    "sha256": "9fb17bd6ac139df01b52e2e712046ae5f2482ef6e3d10891cb5cb6a817c624ab"
+                    "sha256": "c4a9f784be770a9467ac155ab3f74d8a054b0acd4c1b7f933f9a7becd3d56e33"
                 },
                 {
                   "type": "file",


### PR DESCRIPTION
- bumped `org.freedesktop.Platform` -> 25.08;
- bumped `org.freedesktop.Sdk.Extension.openjdk11` to `org.freedesktop.Sdk.Extension.openjdk17`; and
- fixed installer hash to allow build to run.

Closes #16 